### PR TITLE
change prompt

### DIFF
--- a/show_status.sh
+++ b/show_status.sh
@@ -6,7 +6,7 @@ if [ -z "$myip" ]
 then
   /usr/sbin/eips 11 32 "No Wifi connection detected"
 else
-  /usr/sbin/eips 11 32 "Current address: http://$myip"
+  /usr/sbin/eips 11 32 "Visit: http://$myip"
 fi
 
 #check if fileserver is running


### PR DESCRIPTION
The default prompt message is too long on my kpw2 and  ip address can't be full displayed.
Changed to shorter message works good on my device. 